### PR TITLE
Fix a few typos and outdated API usage to enable running with latest versions of matplotlib & scipy & sklearn

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ typical use: $ python main.py -expName -run -plot -show
 
 * **`-vecfield` experiment (Fig. 1):** `-run` needed, but short (~10min)
   ```
-  python main.py -vecfield -plot -show
+  python main.py -vecfield -run -plot -show
   ```
 * **`-misspec` experiment (Fig. 2):** `-run` not needed
   ```

--- a/experiments/main.py
+++ b/experiments/main.py
@@ -42,7 +42,11 @@ def parse():
 
 def savefigs(figs, expname):
     for i, fig in enumerate(figs):
-        efplt.save(fig, expname + "-" + str(i) + ".pdf")
+        if isinstance(fig, list):
+            for j, f in enumerate(fig):
+                efplt.save(f, expname + "-" + str(i) + "-" + str(j) + ".pdf")
+        else:
+            efplt.save(fig, expname + "-" + str(i) + ".pdf")
 
 
 if __name__ == "__main__":

--- a/experiments/optim/main.py
+++ b/experiments/optim/main.py
@@ -34,7 +34,7 @@ def load_problem():
     }
     DATASET_TO_PROBLEMS = {
         "BreastCancer": eftk.problem_defs.LogisticRegression,
-        "Boston": eftk.problem_defs.LinearRegression,
+        "Wine": eftk.problem_defs.LinearRegression,
         "a1a": eftk.problem_defs.LogisticRegression,
     }
     LRS = np.logspace(-20, 10, 241)

--- a/experiments/optim/plotter.py
+++ b/experiments/optim/plotter.py
@@ -51,15 +51,16 @@ def make_angle_single_figure_grid():
     return fig, fig.add_subplot(gs1[0]), fig.add_subplot(gs2[0])
 
 
-def make_angle_figure_grid():
-    fig = plt.figure(figsize=(12, 3))
-    gs1 = matplotlib.gridspec.GridSpec(ncols=3, nrows=1, figure=fig)
-    gs2 = matplotlib.gridspec.GridSpec(ncols=3, nrows=1, figure=fig)
+def make_angle_figure_grid(ncols):
+    fig = plt.figure(figsize=(ncols*4, 3))
+    
+    gs1 = matplotlib.gridspec.GridSpec(ncols=ncols, nrows=1, figure=fig)
+    gs2 = matplotlib.gridspec.GridSpec(ncols=ncols, nrows=1, figure=fig)
     gs1.update(left=0.08, right=0.98, bottom=0.475, top=0.88, hspace=0.15, wspace=0.15)
     gs2.update(left=0.08, right=0.98, bottom=0.18, top=0.425, hspace=0.15, wspace=0.15)
 
-    axes1 = [fig.add_subplot(gs1[0]), fig.add_subplot(gs1[1]), fig.add_subplot(gs1[2])]
-    axes2 = [fig.add_subplot(gs2[0]), fig.add_subplot(gs2[1]), fig.add_subplot(gs2[2])]
+    axes1 = [fig.add_subplot(gs1[i]) for i in range(ncols)]
+    axes2 = [fig.add_subplot(gs2[i]) for i in range(ncols)]
 
     return fig, axes1, axes2
 
@@ -208,10 +209,11 @@ def make_individual_angle_plots(dataset_to_problems, results, N_ITERS, startingP
 
 def make_angle_plot(dataset_to_problems, results, N_ITERS, startingPointFunc):
 
-    fig, axes1, axes2 = make_angle_figure_grid()
+    fig, axes1, axes2 = make_angle_figure_grid(len(dataset_to_problems))
 
     for i, dname in enumerate(dataset_to_problems):
         problemFunc = dataset_to_problems[dname]
+    
         make_angle_single_plot(axes1[i], axes2[i], dname, problemFunc, results, N_ITERS, startingPointFunc, writelabels=(i == 0))
 
         if dname is "a1a":
@@ -237,7 +239,7 @@ def make_angle_plot(dataset_to_problems, results, N_ITERS, startingPointFunc):
 
 def plot(optimizers, dataset_to_problems, lrs, dampings, N_ITERS, startingPointFunc, results):
     angle_fig = make_angle_plot(dataset_to_problems, results, N_ITERS, startingPointFunc)
-    startingpoint_fig = make_starting_point_plot("Boston", dataset_to_problems["Boston"], optimizers, results["Boston"])
+    startingpoint_fig = make_starting_point_plot("Wine", dataset_to_problems["Wine"], optimizers, results["Wine"])
     return angle_fig, startingpoint_fig
 
 

--- a/experiments/vecfield/main.py
+++ b/experiments/vecfield/main.py
@@ -41,22 +41,22 @@ def load_problem():
     return vectorFunctions(gammas, problem), startingPoints, X, y, problem
 
 
-def run(variant):
+def run():
     vectorFuncs, startingPoints, X, y, problem = load_problem()
     results = runner.run(vectorFuncs, startingPoints)
     save_results(results)
 
 
-def plot(variant):
+def plot():
     vectorFuncs, startingPoints, X, y, problem = load_problem()
     results = load_results()
     fig = plotter.plot(X, y, problem, vectorFuncs, startingPoints, results)
     return [fig]
 
 
-def run_appendix(variant):
+def run_appendix():
     print("This experiment has no appendix.")
 
 
-def plot_appendix(variant):
+def plot_appendix():
     print("This experiment has no appendix.")

--- a/libs/efplt/efplt/__init__.py
+++ b/libs/efplt/efplt/__init__.py
@@ -7,7 +7,7 @@ import scipy as sp
 font = {'family': 'serif', 'size': 18}
 matplotlib.rc('font', **font)
 matplotlib.rcParams['text.usetex'] = True
-matplotlib.rcParams['text.latex.preamble'] = [r"\usepackage{amsmath}"]
+matplotlib.rcParams['text.latex.preamble'] = r"\usepackage{amsmath}"
 
 
 def rgb_to_u(xs):

--- a/libs/eftk/eftk/solvers.py
+++ b/libs/eftk/eftk/solvers.py
@@ -20,6 +20,6 @@ def cg(problem):
 
 
 def lbfgs(problem):
-    theta = np.zeros((problem.D, 1))
+    theta = np.zeros(problem.D)
     res = sp.optimize.minimize(fun=problem.loss, x0=theta, jac=problem.g)
     return res.x, res.message


### PR DESCRIPTION
It's impressive to see a great paper with visualization code published. However, there're some typos and outdated API usages in the code that prevent one from reproducing the experiments using the  commands provided in `README.md`. This pull request provide a fast fix.

The following lists the changes made to the codes:

experiments/optim: 
- change boston dataset to wine for boston is removed from sklearn from version in 1.2 (cannot be loaded with sklearn).
- [bugfix] fix index_out_of_range error when running appendix exp for optim.

experiments/vecfield:
- [bugfix] experiments/vecfield/main.py: remove redundant `variant` arg as it causes error when called upon.

experiments/main.py:
- fix error when saving multiple figures at once.

libs/efplt/efplt/__init__.py: 
- update preamble to be str as it causes error in latest version of matplotlib (ref: https://github.com/matplotlib/matplotlib/issues/26464).

libs/eftk/eftk/solvers.py: 
- change ndim of scipy optimizer input as multiple dimension input is deprecated after SciPy 1.11.0.